### PR TITLE
C.UTF-8 для Debian-based дистрибутивов

### DIFF
--- a/cis.command
+++ b/cis.command
@@ -1,6 +1,9 @@
-#!/bin/bash
+#!/bin/bash 
 HONDIR=`dirname "$0"`
 pushd "$HONDIR"
+if [[ -e /etc/debian_version ]]; then 
+	export LANG=C.UTF-8
+fi
 if [[ `uname` == 'Darwin' ]]; then
 	export LC_ALL=C
 fi

--- a/cis_debug.command
+++ b/cis_debug.command
@@ -1,6 +1,9 @@
 #!/bin/bash
 HONDIR=`dirname "$0"`
 pushd "$HONDIR"
+if [[ -e /etc/debian_version ]]; then 
+        export LANG=C.UTF-8
+fi
 if [[ `uname` == 'Darwin' ]]; then
         export LC_ALL=C
 fi


### PR DESCRIPTION
Раз уж C.UTF-8 исконно Debian поделка, то и применять её стоит только в Debian-based дистрах. Проблема только у ru_RU локали, так что хватит одного cis. Остальным господам думать самим и слать патчи :)
